### PR TITLE
[8.2] - Add fix for CVE-2025-26465

### DIFF
--- a/SOURCES/openssh-7.4p1-CVE-2025-26465-Fix-cases-where-error-codes-were-not-correc.patch
+++ b/SOURCES/openssh-7.4p1-CVE-2025-26465-Fix-cases-where-error-codes-were-not-correc.patch
@@ -1,0 +1,82 @@
+Backport notes:
+Drop comment on the original commit about last update.
+Adapt the patch to our version by adding r as return value.
+
+Original commit:
+From 0832aac79517611dd4de93ad0a83577994d9c907 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Tue, 18 Feb 2025 08:02:48 +0000
+Subject: [PATCH] upstream: Fix cases where error codes were not correctly set
+
+Reported by the Qualys Security Advisory team. ok markus@
+
+OpenBSD-Commit-ID: 7bcd4ffe0fa1e27ff98d451fb9c22f5fae6e610d
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ krl.c         | 2 ++
+ sshconnect2.c | 7 +++++--
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/krl.c b/krl.c
+index e2efdf066..0d0f69534 100644
+--- a/krl.c
++++ b/krl.c
+@@ -647,6 +647,7 @@ revoked_certs_generate(struct revoked_certs *rc, struct sshbuf *buf)
+ 			break;
+ 		case KRL_SECTION_CERT_SERIAL_BITMAP:
+ 			if (rs->lo - bitmap_start > INT_MAX) {
++				r = SSH_ERR_INVALID_FORMAT;
+ 				error("%s: insane bitmap gap", __func__);
+ 				goto out;
+ 			}
+@@ -947,6 +948,7 @@ ssh_krl_from_blob(struct sshbuf *buf, struct ssh_krl **krlp,
+ 		goto out;
+ 
+ 	if ((krl = ssh_krl_init()) == NULL) {
++		r = SSH_ERR_ALLOC_FAIL;
+ 		error("%s: alloc failed", __func__);
+ 		goto out;
+ 	}
+diff --git a/sshconnect2.c b/sshconnect2.c
+index a69c4da18..1ee6000ab 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -650,6 +650,7 @@ input_userauth_pk_ok(int type, u_int32_t seq, void *ctxt)
+ 	u_int alen, blen;
+ 	char *pkalg, *fp;
+ 	u_char *pkblob;
++	int r = 0;
+ 
+ 	if (authctxt == NULL)
+ 		fatal("input_userauth_pk_ok: no authentication context");
+@@ -671,6 +672,7 @@ input_userauth_pk_ok(int type, u_int32_t seq, void *ctxt)
+ 
+ 	if ((pktype = key_type_from_name(pkalg)) == KEY_UNSPEC) {
+ 		debug("unknown pkalg %s", pkalg);
++		r = SSH_ERR_INVALID_FORMAT;
+ 		goto done;
+ 	}
+ 	if ((key = key_from_blob(pkblob, blen)) == NULL) {
+@@ -681,6 +683,7 @@ input_userauth_pk_ok(int type, u_int32_t seq, void *ctxt)
+ 		error("input_userauth_pk_ok: type mismatch "
+ 		    "for decoded key (received %d, expected %d)",
+ 		    key->type, pktype);
++		r = SSH_ERR_INVALID_FORMAT;
+ 		goto done;
+ 	}
+ 	if ((fp = sshkey_fingerprint(key, options.fingerprint_hash[0],
+@@ -707,9 +710,9 @@ done:
+ 	free(pkblob);
+ 
+ 	/* try another method if we did not send a packet */
+-	if (sent == 0)
++	if (r == 0 && sent == 0)
+ 		userauth(authctxt, NULL);
+-	return 0;
++	return r;
+ }
+ 
+ #ifdef GSSAPI
+-- 
+2.47.0
+

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -10,7 +10,7 @@
 %endif
 
 # XCP-ng sub release number
-%define xcpng_subrel 1
+%define xcpng_subrel 2
 
 # OpenSSH privilege separation requires a user & group ID
 %define sshd_uid    74
@@ -176,6 +176,7 @@ Patch78: openssh-9.8p1-cve-2024-6387.patch
 # XCP-ng patches
 Patch1000: xcpng-harden-default-ciphers-and-algorithms.patch
 Patch1001: xcpng-disable-gssapiauth-in-sshd_config.patch
+Patch1002: openssh-7.4p1-CVE-2025-26465-Fix-cases-where-error-codes-were-not-correc.patch
 
 License: BSD
 Group: Applications/Internet
@@ -657,6 +658,9 @@ getent passwd sshd >/dev/null || \
 %endif
 
 %changelog
+* Mon Mar 17 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 7.4p1-23.3.2 + 0.10.3-2.23.3.2
+- Fix CVE-2025-26465 - Fix cases where error codes were not correctly set
+
 * Tue Nov 12 2024 Thierry Escande <thierry.escande@vates.tech> - 7.4p1-23.3.1 + 0.10.3-2.1
 - Update to 7.4p1-23.3 + 0.10.3-2
 - *** Upstream changelog ***


### PR DESCRIPTION
A vulnerability was found in OpenSSH when the VerifyHostKeyDNS option is enabled. A machine-in-the-middle attack can be performed by a malicious machine impersonating a legit server.
This issue occurs due to how OpenSSH mishandles err codes in specific conditions when verifying the host key.
For an attack to be considered successful, attacker needs to manage to exhaust the client's memory resource first,
turning the attack complexity high.

In the patch:
- Added error codes
- Added missing structures