### PR TITLE
Fix: Potential ECDSA and CA Authorized_Keys ByPass

### DIFF
--- a/SOURCES/openssh-9.8p1-CVE-2026-35414-regression-test-for-certificates.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2026-35414-regression-test-for-certificates.patch
@@ -1,0 +1,103 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/ecdf9b9f8e89aae65d4a12fe5a25c560eea08393
+Backport notes:
+- Only the "sh" file headers were modified.
+
+From ecdf9b9f8e89aae65d4a12fe5a25c560eea08393 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 22 Dec 2025 01:50:46 +0000
+Subject: [PATCH] upstream: regression tests for certificates with empty
+ principals
+
+sections (which are now unconditionally refused) and for certificates with
+wildcard principals (which should only be accepted in host certs)
+
+OpenBSD-Regress-ID: fdca88845a68424060547b4f9f32f90a7cf82e73
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ regress/cert-hostkey.sh | 28 +++++++++++++++++-----------
+ regress/cert-userkey.sh |  9 ++++-----
+ 2 files changed, 21 insertions(+), 16 deletions(-)
+
+diff --git a/regress/cert-hostkey.sh b/regress/cert-hostkey.sh
+index bfdd3588d..9061cc702 100644
+--- a/regress/cert-hostkey.sh
++++ b/regress/cert-hostkey.sh
+@@ -1,4 +1,4 @@
+-#	$OpenBSD: cert-hostkey.sh,v 1.27 2021/09/30 05:26:26 dtucker Exp $
++#	$OpenBSD: cert-hostkey.sh,v 1.29 2025/12/22 01:50:46 djm Exp $
+ #	Placed in the Public Domain.
+ 
+ tid="certified host keys"
+@@ -208,9 +208,12 @@ kh_ca host_ca_key.pub host_ca_key2.pub > $OBJ/known_hosts-cert.orig
+ cp $OBJ/known_hosts-cert.orig $OBJ/known_hosts-cert
+ 
+ test_one() {
+-	ident=$1
+-	result=$2
+-	sign_opts=$3
++	ident="$1"
++	result="$2"
++	hosts="$3"
++	sign_opts="$4"
++
++	test -z "$hosts" || sign_opts="$sign_opts -n $hosts"
+ 
+ 	for kt in $PLAIN_TYPES; do
+ 		case $ktype in
+@@ -243,13 +246,16 @@ test_one() {
+ 	done
+ }
+ 
+-test_one "user-certificate"	failure "-n $HOSTS"
+-test_one "empty principals"	success "-h"
+-test_one "wrong principals"	failure "-h -n foo"
+-test_one "cert not yet valid"	failure "-h -V20300101:20320101"
+-test_one "cert expired"		failure "-h -V19800101:19900101"
+-test_one "cert valid interval"	success "-h -V-1w:+2w"
+-test_one "cert has constraints"	failure "-h -Oforce-command=false"
++test_one "simple"		success $HOSTS	"-h"
++test_one "wildcard"		success "loc*"	"-h"
++test_one "user-certificate"	failure $HOSTS
++test_one "wildcard user"	failure "local*"
++test_one "empty principals"	failure ""	"-h"
++test_one "wrong principals"	failure foo	"-h"
++test_one "cert not yet valid"	failure $HOSTS	"-h -V20300101:20320101"
++test_one "cert expired"		failure $HOSTS	"-h -V19800101:19900101"
++test_one "cert valid interval"	success $HOSTS	"-h -V-1w:+2w"
++test_one "cert has constraints"	failure $HOSTS	"-h -Oforce-command=false"
+ 
+ # Check downgrade of cert to raw key when no CA found
+ for ktype in $PLAIN_TYPES ; do
+diff --git a/regress/cert-userkey.sh b/regress/cert-userkey.sh
+index 39bb432..cd2d896 100644
+--- a/regress/cert-userkey.sh
++++ b/regress/cert-userkey.sh
+@@ -1,4 +1,4 @@
+-#	$OpenBSD: cert-userkey.sh,v 1.28 2021/09/30 05:26:26 dtucker Exp $
++#	$OpenBSD: cert-userkey.sh,v 1.31 2025/12/22 01:50:46 djm Exp $
+ #	Placed in the Public Domain.
+ 
+ tid="certified user keys"
+@@ -331,16 +331,15 @@ test_one() {
+ }
+ 
+ test_one "correct principal"	success "-n ${USER}"
++test_one "correct principal"	success "-n ${USER},*"
+ test_one "host-certificate"	failure "-n ${USER} -h"
+-test_one "wrong principals"	failure "-n foo"
++test_one "wrong principals"	failure "-n foo,*"
+ test_one "cert not yet valid"	failure "-n ${USER} -V20300101:20320101"
+ test_one "cert expired"		failure "-n ${USER} -V19800101:19900101"
+ test_one "cert valid interval"	success "-n ${USER} -V-1w:+2w"
+ test_one "wrong source-address"	failure "-n ${USER} -Osource-address=10.0.0.0/8"
+ test_one "force-command"	failure "-n ${USER} -Oforce-command=false"
+-
+-# Behaviour is different here: TrustedUserCAKeys doesn't allow empty principals
+-test_one "empty principals"	success "" authorized_keys
++test_one "empty principals"	failure "" authorized_keys
+ test_one "empty principals"	failure "" TrustedUserCAKeys
+ 
+ # Check explicitly-specified principals: an empty principals list in the cert
+-- 
+2.53.0
+

--- a/SOURCES/openssh-9.8p1-CVE-2026-35414-when-certificate-support-was-added.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2026-35414-when-certificate-support-was-added.patch
@@ -1,0 +1,418 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/5166b6cbf2b6103117a79f90a68068e89e02bf66
+Backport notes:
+- Only the "c" file headers were modified.
+
+From 5166b6cbf2b6103117a79f90a68068e89e02bf66 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 22 Dec 2025 01:49:03 +0000
+Subject: [PATCH] upstream: When certificate support was added to OpenSSH,
+
+certificates were originally specified to represent any principal if the
+principals list was empty.
+
+This was, in retrospect, a mistake as it created a fail-open
+situation if a CA could be convinced to accidentally sign a
+certificate with no principals. This actually happened in a 3rd-
+party CA product (CVE-2024-7594).
+
+Somewhat fortunately, the main pathway for using certificates in
+sshd (TrustedUserCAKeys) never supported empty-principals
+certificates, so the blast radius of such mistakes was
+substantially reduced.
+
+This change removes this footcannon and requires all certificates
+include principals sections. It also fixes interpretation of
+wildcard principals, and properly enables them for host
+certificates only.
+
+This is a behaviour change that will permanently break uses of
+certificates with empty principals sections.
+
+ok markus@
+
+OpenBSD-Commit-ID: 0a901f03c567c100724a492cf91e02939904712e
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ auth2-hostbased.c  |  6 ++---
+ auth2-pubkey.c     |  4 ++--
+ auth2-pubkeyfile.c |  4 ++--
+ ssh-agent.c        |  4 ++--
+ ssh-keygen.1       | 34 +++++++++++++++++++--------
+ ssh-keygen.c       | 11 ++++++++-
+ sshconnect.c       |  4 ++--
+ sshkey.c           | 57 ++++++++++++++++++++++------------------------
+ sshkey.h           |  8 +++----
+ sshsig.c           |  8 +++----
+ 10 files changed, 80 insertions(+), 60 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index 9d8b860eb..e2ed8b3eb 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-hostbased.c,v 1.54 2025/08/06 04:53:04 djm Exp $ */
++/* $OpenBSD: auth2-hostbased.c,v 1.56 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  *
+@@ -234,8 +234,8 @@ hostbased_key_allowed(struct ssh *ssh, struct passwd *pw,
+ 	}
+ 	debug2_f("access allowed by auth_rhosts2");
+ 
+-	if (sshkey_is_cert(key) &&
+-	    sshkey_cert_check_authority_now(key, 1, 0, 0, lookup, &reason)) {
++	if (sshkey_is_cert(key) && sshkey_cert_check_host(key, lookup,
++	     options.ca_sign_algorithms, &reason) != 0) {
+ 		if ((fp = sshkey_fingerprint(key->cert->signature_key,
+ 		    options.fingerprint_hash, SSH_FP_DEFAULT)) == NULL)
+ 			fatal_f("sshkey_fingerprint fail");
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index ebc14fb..573a6ca 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-pubkey.c,v 1.123 2025/08/06 04:53:04 djm Exp $ */
++/* $OpenBSD: auth2-pubkey.c,v 1.125 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2010 Damien Miller.  All rights reserved.
+@@ -564,7 +564,7 @@ user_cert_trusted_ca(struct passwd *pw, struct sshkey *key,
+ 	}
+ 	if (use_authorized_principals && principals_opts == NULL)
+ 		fatal_f("internal error: missing principals_opts");
+-	if (sshkey_cert_check_authority_now(key, 0, 1, 0,
++	if (sshkey_cert_check_authority_now(key, 0, 0,
+ 	    use_authorized_principals ? NULL : pw->pw_name, &reason) != 0)
+ 		goto fail_reason;
+ 
+diff --git a/auth2-pubkeyfile.c b/auth2-pubkeyfile.c
+index 531a266..2ea4083 100644
+--- a/auth2-pubkeyfile.c
++++ b/auth2-pubkeyfile.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-pubkeyfile.c,v 1.5 2025/08/06 04:53:04 djm Exp $ */
++/* $OpenBSD: auth2-pubkeyfile.c,v 1.7 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2010 Damien Miller.  All rights reserved.
+@@ -364,7 +364,7 @@ auth_check_authkey_line(struct passwd *pw, struct sshkey *key,
+ 		reason = "Certificate does not contain an authorized principal";
+ 		goto cert_fail_reason;
+ 	}
+-	if (sshkey_cert_check_authority_now(key, 0, 0, 0,
++	if (sshkey_cert_check_authority_now(key, 0, 0,
+ 	    keyopts->cert_principals == NULL ? pw->pw_name : NULL,
+ 	    &reason) != 0)
+ 		goto cert_fail_reason;
+diff --git a/ssh-agent.c b/ssh-agent.c
+index b69d520..031d4c5 100644
+--- a/ssh-agent.c
++++ b/ssh-agent.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: ssh-agent.c,v 1.306 2024/03/09 05:12:13 djm Exp $ */
++/* $OpenBSD: ssh-agent.c,v 1.316 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Author: Tatu Ylonen <ylo@cs.hut.fi>
+  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -397,7 +397,7 @@ match_key_hop(const char *tag, const struct sshkey *key,
+ 			return -1; /* shouldn't happen */
+ 		if (!sshkey_equal(key->cert->signature_key, dch->keys[i]))
+ 			continue;
+-		if (sshkey_cert_check_host(key, hostname, 1,
++		if (sshkey_cert_check_host(key, hostname,
+ 		    SSH_ALLOWED_CA_SIGALGS, &reason) != 0) {
+ 			debug_f("cert %s / hostname %s rejected: %s",
+ 			    key->cert->key_id, hostname, reason);
+diff --git a/ssh-keygen.1 b/ssh-keygen.1
+index df6803f..10951ae 100644
+--- a/ssh-keygen.1
++++ b/ssh-keygen.1
+@@ -1,4 +1,4 @@
+-.\"	$OpenBSD: ssh-keygen.1,v 1.232 2024/06/17 13:50:18 naddy Exp $
++.\"	$OpenBSD: ssh-keygen.1,v 1.237 2025/12/22 01:49:03 djm Exp $
+ .\"
+ .\" Author: Tatu Ylonen <ylo@cs.hut.fi>
+ .\" Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -35,7 +35,7 @@
+ .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ .\"
+-.Dd $Mdocdate: June 17 2024 $
++.Dd $Mdocdate: December 22 2025 $
+ .Dt SSH-KEYGEN 1
+ .Os
+ .Sh NAME
+@@ -905,15 +905,29 @@ User certificates authenticate users to servers, whereas host certificates
+ authenticate server hosts to users.
+ To generate a user certificate:
+ .Pp
+-.Dl $ ssh-keygen -s /path/to/ca_key -I key_id /path/to/user_key.pub
++.Dl $ ssh-keygen -s /path/to/ca_key -I id -n user \e
++.Dl \ \ \ \ \ \ /path/to/user_key.pub
+ .Pp
+ The resultant certificate will be placed in
+ .Pa /path/to/user_key-cert.pub .
++The argument to
++.Fl I
++is a key identifier that will be used in logs and may be used to revoke
++keys.
++The argument to
++.Fl n
++is one or more (comma-separated) principals, typically usernames, that
++the certificate represents.
+ A host certificate requires the
+ .Fl h
+ option:
+ .Pp
+-.Dl $ ssh-keygen -s /path/to/ca_key -I key_id -h /path/to/host_key.pub
++.Dl $ ssh-keygen -s /path/to/ca_key -I id -h -n foo.example.org \e
++.Dl \ \ \ \ \ \ /path/to/host_key.pub
++.Pp
++For host certificates, the principals specified using the
++.Fl n
++argument are hostnames and may contain wildcard characters.
+ .Pp
+ The host certificate will be output to
+ .Pa /path/to/host_key-cert.pub .
+@@ -925,7 +939,8 @@ and identifying the CA key by providing its public half as an argument
+ to
+ .Fl s :
+ .Pp
+-.Dl $ ssh-keygen -s ca_key.pub -D libpkcs11.so -I key_id user_key.pub
++.Dl $ ssh-keygen -s ca_key.pub -D libpkcs11.so -I id -n user \e
++.Dl \ \ \ \ \ \ user_key.pub
+ .Pp
+ Similarly, it is possible for the CA key to be hosted in a
+ .Xr ssh-agent 1 .
+@@ -933,20 +948,19 @@ This is indicated by the
+ .Fl U
+ flag and, again, the CA key must be identified by its public half.
+ .Pp
+-.Dl $ ssh-keygen -Us ca_key.pub -I key_id user_key.pub
++.Dl $ ssh-keygen -Us ca_key.pub -I id -n user user_key.pub
+ .Pp
+ In all cases,
+ .Ar key_id
+ is a "key identifier" that is logged by the server when the certificate
+ is used for authentication.
+ .Pp
+-Certificates may be limited to be valid for a set of principal (user/host)
++Certificates are limited to be valid for a set of principal (user/host)
+ names.
+-By default, generated certificates are valid for all users or hosts.
+ To generate a certificate for a specified set of principals:
+ .Pp
+-.Dl $ ssh-keygen -s ca_key -I key_id -n user1,user2 user_key.pub
+-.Dl "$ ssh-keygen -s ca_key -I key_id -h -n host.domain host_key.pub"
++.Dl $ ssh-keygen -s ca_key -I id -n user1,user2 user_key.pub
++.Dl $ ssh-keygen -s ca_key -I id -h -n host.domain host_key.pub
+ .Pp
+ Additional limitations on the validity and use of user certificates may
+ be specified through certificate options.
+diff --git a/ssh-keygen.c b/ssh-keygen.c
+index 2ae9dd6..44e9b0e 100644
+--- a/ssh-keygen.c
++++ b/ssh-keygen.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: ssh-keygen.c,v 1.472 2024/01/11 01:45:36 djm Exp $ */
++/* $OpenBSD: ssh-keygen.c,v 1.488 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Author: Tatu Ylonen <ylo@cs.hut.fi>
+  * Copyright (c) 1994 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -3735,6 +3735,15 @@ main(int argc, char **argv)
+ 	if (ca_key_path != NULL) {
+ 		if (cert_key_id == NULL)
+ 			fatal("Must specify key id (-I) when certifying");
++		if (cert_principals == NULL) {
++			/*
++			 * Ideally this would be a fatal(), but we need to
++			 * be able to generate such certificates for testing
++			 * even though they will be rejected.
++			 */
++			error("Warning: certificate will contain no "
++			    "principals (-n)");
++		}
+ 		for (i = 0; i < nopts; i++)
+ 			add_cert_option(opts[i]);
+ 		do_ca_sign(pw, ca_key_path, prefer_agent,
+diff --git a/sshconnect.c b/sshconnect.c
+index 0ace840..5203c72 100644
+--- a/sshconnect.c
++++ b/sshconnect.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshconnect.c,v 1.368 2024/04/30 02:10:49 djm Exp $ */
++/* $OpenBSD: sshconnect.c,v 1.377 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Author: Tatu Ylonen <ylo@cs.hut.fi>
+  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -1092,7 +1092,7 @@ check_host_key(char *hostname, const struct ssh_conn_info *cinfo,
+ 		if (want_cert) {
+ 			if (sshkey_cert_check_host(host_key,
+ 			    options.host_key_alias == NULL ?
+-			    hostname : options.host_key_alias, 0,
++			    hostname : options.host_key_alias,
+ 			    options.ca_sign_algorithms, &fail_reason) != 0) {
+ 				error("%s", fail_reason);
+ 				goto fail;
+diff --git a/sshkey.c b/sshkey.c
+index 2e17242..0f2703d 100644
+--- a/sshkey.c
++++ b/sshkey.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshkey.c,v 1.142 2024/01/11 01:45:36 djm Exp $ */
++/* $OpenBSD: sshkey.c,v 1.159 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Copyright (c) 2000, 2001 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2008 Alexander von Gernler.  All rights reserved.
+@@ -2523,8 +2523,8 @@ sshkey_certify(struct sshkey *k, struct sshkey *ca, const char *alg,
+ 
+ int
+ sshkey_cert_check_authority(const struct sshkey *k,
+-    int want_host, int require_principal, int wildcard_pattern,
+-    uint64_t verify_time, const char *name, const char **reason)
++    int want_host, int wildcard_pattern, uint64_t verify_time,
++    const char *name, const char **reason)
+ {
+ 	u_int i, principal_matches;
+ 
+@@ -2554,37 +2554,36 @@ sshkey_cert_check_authority(const struct sshkey *k,
+ 		return SSH_ERR_KEY_CERT_INVALID;
+ 	}
+ 	if (k->cert->nprincipals == 0) {
+-		if (require_principal) {
+-			*reason = "Certificate lacks principal list";
+-			return SSH_ERR_KEY_CERT_INVALID;
+-		}
+-	} else if (name != NULL) {
+-		principal_matches = 0;
+-		for (i = 0; i < k->cert->nprincipals; i++) {
+-			if (wildcard_pattern) {
+-				if (match_pattern(k->cert->principals[i],
+-				    name)) {
+-					principal_matches = 1;
+-					break;
+-				}
+-			} else if (strcmp(name, k->cert->principals[i]) == 0) {
++		*reason = "Certificate lacks principal list";
++		return SSH_ERR_KEY_CERT_INVALID;
++	}
++	if (name == NULL)
++		return 0; /* principal matching not requested */
++
++	principal_matches = 0;
++	for (i = 0; i < k->cert->nprincipals; i++) {
++		if (wildcard_pattern) {
++			if (match_pattern(name, k->cert->principals[i])) {
+ 				principal_matches = 1;
+ 				break;
+ 			}
++		} else if (strcmp(name, k->cert->principals[i]) == 0) {
++			principal_matches = 1;
++			break;
+ 		}
+-		if (!principal_matches) {
+-			*reason = "Certificate invalid: name is not a listed "
+-			    "principal";
+-			return SSH_ERR_KEY_CERT_INVALID;
+-		}
++	}
++	if (!principal_matches) {
++		*reason = "Certificate invalid: name is not a listed "
++		    "principal";
++		return SSH_ERR_KEY_CERT_INVALID;
+ 	}
+ 	return 0;
+ }
+ 
+ int
+ sshkey_cert_check_authority_now(const struct sshkey *k,
+-    int want_host, int require_principal, int wildcard_pattern,
+-    const char *name, const char **reason)
++    int want_host, int wildcard_pattern, const char *name,
++    const char **reason)
+ {
+ 	time_t now;
+ 
+@@ -2593,19 +2592,17 @@ sshkey_cert_check_authority_now(const struct sshkey *k,
+ 		*reason = "Certificate invalid: not yet valid";
+ 		return SSH_ERR_KEY_CERT_INVALID;
+ 	}
+-	return sshkey_cert_check_authority(k, want_host, require_principal,
+-	    wildcard_pattern, (uint64_t)now, name, reason);
++	return sshkey_cert_check_authority(k, want_host, wildcard_pattern,
++	    (uint64_t)now, name, reason);
+ }
+ 
+ int
+ sshkey_cert_check_host(const struct sshkey *key, const char *host,
+-    int wildcard_principals, const char *ca_sign_algorithms,
+-    const char **reason)
++    const char *ca_sign_algorithms, const char **reason)
+ {
+ 	int r;
+ 
+-	if ((r = sshkey_cert_check_authority_now(key, 1, 0, wildcard_principals,
+-	    host, reason)) != 0)
++	if ((r = sshkey_cert_check_authority_now(key, 1, 1, host, reason)) != 0)
+ 		return r;
+ 	if (sshbuf_len(key->cert->critical) != 0) {
+ 		*reason = "Certificate contains unsupported critical options";
+diff --git a/sshkey.h b/sshkey.h
+index 11fc073..1c20a6d 100644
+--- a/sshkey.h
++++ b/sshkey.h
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshkey.h,v 1.63 2024/05/17 06:42:04 jsg Exp $ */
++/* $OpenBSD: sshkey.h,v 1.71 2025/12/22 01:49:03 djm Exp $ */
+ 
+ /*
+  * Copyright (c) 2000, 2001 Markus Friedl.  All rights reserved.
+@@ -239,12 +239,12 @@ int	 sshkey_match_keyname_to_sigalgs(const char *, const char *);
+ int	 sshkey_to_certified(struct sshkey *);
+ int	 sshkey_drop_cert(struct sshkey *);
+ int	 sshkey_cert_copy(const struct sshkey *, struct sshkey *);
+-int	 sshkey_cert_check_authority(const struct sshkey *, int, int, int,
++int	 sshkey_cert_check_authority(const struct sshkey *, int, int,
+     uint64_t, const char *, const char **);
+-int	 sshkey_cert_check_authority_now(const struct sshkey *, int, int, int,
++int	 sshkey_cert_check_authority_now(const struct sshkey *, int, int,
+     const char *, const char **);
+ int	 sshkey_cert_check_host(const struct sshkey *, const char *,
+-    int , const char *, const char **);
++    const char *, const char **);
+ size_t	 sshkey_format_cert_validity(const struct sshkey_cert *,
+     char *, size_t) __attribute__((__bounded__(__string__, 2, 3)));
+ int	 sshkey_check_cert_sigtype(const struct sshkey *, const char *);
+diff --git a/sshsig.c b/sshsig.c
+index 057e1df..d30a0d1 100644
+--- a/sshsig.c
++++ b/sshsig.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshsig.c,v 1.35 2024/03/08 22:16:32 djm Exp $ */
++/* $OpenBSD: sshsig.c,v 1.41 2025/12/22 01:49:03 djm Exp $ */
+ /*
+  * Copyright (c) 2019 Google LLC
+  *
+@@ -849,8 +849,8 @@ cert_filter_principals(const char *path, u_long linenum,
+ 
+ 	while ((cp = strsep(&principals, ",")) != NULL && *cp != '\0') {
+ 		/* Check certificate validity */
+-		if ((r = sshkey_cert_check_authority(cert, 0, 1, 0,
+-		    verify_time, NULL, &reason)) != 0) {
++		if ((r = sshkey_cert_check_authority(cert, 0, 0, verify_time,
++		    NULL, &reason)) != 0) {
+ 			debug("%s:%lu: principal \"%s\" not authorized: %s",
+ 			    path, linenum, cp, reason);
+ 			continue;
+@@ -915,7 +915,7 @@ check_allowed_keys_line(const char *path, u_long linenum, char *line,
+ 	    sshkey_equal_public(sign_key->cert->signature_key, found_key)) {
+ 		if (principal) {
+ 			/* Match certificate CA key with specified principal */
+-			if ((r = sshkey_cert_check_authority(sign_key, 0, 1, 0,
++			if ((r = sshkey_cert_check_authority(sign_key, 0, 0,
+ 			    verify_time, principal, &reason)) != 0) {
+ 				error("%s:%lu: certificate not authorized: %s",
+ 				    path, linenum, reason);
+-- 
+2.53.0
+

--- a/SOURCES/openssh-9.8p1-upstream-correctly-match-ECDSA-signature-algorithms.patch
+++ b/SOURCES/openssh-9.8p1-upstream-correctly-match-ECDSA-signature-algorithms.patch
@@ -1,0 +1,206 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/fd1c7e131f331942d20f42f31e79912d570081fa
+Backport notes:
+- Only the "c" file headers were modified.
+
+From fd1c7e131f331942d20f42f31e79912d570081fa Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:48:13 +0000
+Subject: [PATCH] upstream: correctly match ECDSA signature algorithms against
+
+algorithm allowlists: HostKeyAlgorithms, PubkeyAcceptedAlgorithms and
+HostbasedAcceptedAlgorithms.
+
+Previously, if any ECDSA type (say "ecdsa-sha2-nistp521") was
+present in one of these lists, then all ECDSA algorithms would
+be permitted.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: c790e2687c35989ae34a00e709be935c55b16a86
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ auth2-hostbased.c  |  9 +++++----
+ auth2-pubkey.c     |  9 +++++----
+ auth2-pubkeyfile.c | 26 +++++++++++++++-----------
+ sshconnect2.c      | 28 ++++++++++++++++++----------
+ 4 files changed, 43 insertions(+), 29 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index 8cebaff..87cd86f 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-hostbased.c,v 1.56 2025/12/22 01:49:03 djm Exp $ */
++/* $OpenBSD: auth2-hostbased.c,v 1.57 2026/04/02 07:48:13 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  *
+@@ -96,9 +96,10 @@ userauth_hostbased(struct ssh *ssh, const char *method)
+ 		error_f("cannot decode key: %s", pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error_f("type mismatch for decoded key "
+-		    "(received %d, expected %d)", key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error_f("key type mismatch for decoded key "
++		    "(received %s, expected %s)", sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (match_pattern_list(pkalg, options.hostbased_accepted_algos, 0) != 1) {
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index ed1bc14..4bfa5ba 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-pubkey.c,v 1.125 2025/12/22 01:49:03 djm Exp $ */
++/* $OpenBSD: auth2-pubkey.c,v 1.126 2026/04/02 07:48:13 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2010 Damien Miller.  All rights reserved.
+@@ -152,9 +152,10 @@ userauth_pubkey(struct ssh *ssh, const char *method)
+ 		error_f("cannot decode key: %s", pkalg);
+ 		goto done;
+ 	}
+-	if (key->type != pktype) {
+-		error_f("type mismatch for decoded key "
+-		    "(received %d, expected %d)", key->type, pktype);
++	if (key->type != pktype || (sshkey_type_plain(pktype) == KEY_ECDSA &&
++	    sshkey_ecdsa_nid_from_name(pkalg) != key->ecdsa_nid)) {
++		error_f("key type mismatch for decoded key "
++		    "(received %s, expected %s)", sshkey_ssh_name(key), pkalg);
+ 		goto done;
+ 	}
+ 	if (auth2_key_already_used(authctxt, key)) {
+diff --git a/auth2-pubkeyfile.c b/auth2-pubkeyfile.c
+index 31e7481..869c8e0 100644
+--- a/auth2-pubkeyfile.c
++++ b/auth2-pubkeyfile.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-pubkeyfile.c,v 1.7 2025/12/22 01:49:03 djm Exp $ */
++/* $OpenBSD: auth2-pubkeyfile.c,v 1.8 2026/04/02 07:48:13 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2010 Damien Miller.  All rights reserved.
+@@ -50,6 +50,7 @@
+ #include "authfile.h"
+ #include "match.h"
+ #include "ssherr.h"
++#include "xmalloc.h"
+ 
+ int
+ auth_authorise_keyopts(struct passwd *pw, struct sshauthopt *opts,
+@@ -146,20 +147,23 @@ auth_authorise_keyopts(struct passwd *pw, struct sshauthopt *opts,
+ static int
+ match_principals_option(const char *principal_list, struct sshkey_cert *cert)
+ {
+-	char *result;
++	char *list, *olist, *entry;
+ 	u_int i;
+ 
+-	/* XXX percent_expand() sequences for authorized_principals? */
+-
+-	for (i = 0; i < cert->nprincipals; i++) {
+-		if ((result = match_list(cert->principals[i],
+-		    principal_list, NULL)) != NULL) {
+-			debug3("matched principal from key options \"%.100s\"",
+-			    result);
+-			free(result);
+-			return 1;
++	olist = list = xstrdup(principal_list);
++	for (;;) {
++		if ((entry = strsep(&list, ",")) == NULL || *entry == '\0')
++			break;
++		for (i = 0; i < cert->nprincipals; i++) {
++			if (strcmp(entry, cert->principals[i]) == 0) {
++				debug3("matched principal from key i"
++				    "options \"%.100s\"", entry);
++				free(olist);
++				return 1;
++			}
+ 		}
+ 	}
++	free(olist);
+ 	return 0;
+ }
+ 
+diff --git a/sshconnect2.c b/sshconnect2.c
+index bacc2f9..e64ee79 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sshconnect2.c,v 1.373 2024/05/17 06:38:00 jsg Exp $ */
++/* $OpenBSD: sshconnect2.c,v 1.385 2026/04/02 07:48:13 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2008 Damien Miller.  All rights reserved.
+@@ -93,6 +93,7 @@ extern Options options;
+ static char *xxx_host;
+ static struct sockaddr *xxx_hostaddr;
+ static const struct ssh_conn_info *xxx_conn_info;
++static int key_type_allowed(struct sshkey *, const char *);
+ 
+ static int
+ verify_host_key_callback(struct sshkey *hostkey, struct ssh *ssh)
+@@ -102,6 +103,10 @@ verify_host_key_callback(struct sshkey *hostkey, struct ssh *ssh)
+ 	if ((r = sshkey_check_rsa_length(hostkey,
+ 	    options.required_rsa_size)) != 0)
+ 		fatal_r(r, "Bad server host key");
++	if (!key_type_allowed(hostkey, options.hostkeyalgorithms)) {
++		fatal("Server host key %s not in HostKeyAlgorithms",
++		    sshkey_ssh_name(hostkey));
++	}
+ 	if (verify_host_key(xxx_host, xxx_hostaddr, hostkey,
+ 	    xxx_conn_info) != 0)
+ 		fatal("Host key verification failed.");
+@@ -1779,34 +1784,37 @@ load_identity_file(Identity *id)
+ }
+ 
+ static int
+-key_type_allowed_by_config(struct sshkey *key)
++key_type_allowed(struct sshkey *key, const char *allowlist)
+ {
+-	if (match_pattern_list(sshkey_ssh_name(key),
+-	    options.pubkey_accepted_algos, 0) == 1)
++	if (match_pattern_list(sshkey_ssh_name(key), allowlist, 0) == 1)
+ 		return 1;
+ 
+ 	/* RSA keys/certs might be allowed by alternate signature types */
+ 	switch (key->type) {
+ 	case KEY_RSA:
+-		if (match_pattern_list("rsa-sha2-512",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		if (match_pattern_list("rsa-sha2-512", allowlist, 0) == 1)
+ 			return 1;
+-		if (match_pattern_list("rsa-sha2-256",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		if (match_pattern_list("rsa-sha2-256", allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	case KEY_RSA_CERT:
+ 		if (match_pattern_list("rsa-sha2-512-cert-v01@openssh.com",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		if (match_pattern_list("rsa-sha2-256-cert-v01@openssh.com",
+-		    options.pubkey_accepted_algos, 0) == 1)
++		    allowlist, 0) == 1)
+ 			return 1;
+ 		break;
+ 	}
+ 	return 0;
+ }
+ 
++static int
++key_type_allowed_by_config(struct sshkey *key)
++{
++	return key_type_allowed(key, options.pubkey_accepted_algos);
++}
++
+ /* obtain a list of keys from the agent */
+ static int
+ get_agent_identities(struct ssh *ssh, int *agent_fdp,
+-- 
+2.53.0
+

--- a/SOURCES/openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patch
+++ b/SOURCES/openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patch
@@ -1,0 +1,51 @@
+From 09daf2ac5f248dc5d60a6f3a703b479d67da14b4 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Mon, 22 Dec 2025 03:36:43 +0000
+Subject: [PATCH] upstream: correctly quote wildcard host certificate principal
+ name,
+
+lest it expand to an unrelated filename in the working directory
+
+OpenBSD-Regress-ID: 8a9eb716d3ea7986d26c1a931758b996aa93c58e
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ regress/cert-hostkey.sh | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/regress/cert-hostkey.sh b/regress/cert-hostkey.sh
+index 9061cc702..f15512232 100644
+--- a/regress/cert-hostkey.sh
++++ b/regress/cert-hostkey.sh
+@@ -1,4 +1,4 @@
+-#	$OpenBSD: cert-hostkey.sh,v 1.29 2025/12/22 01:50:46 djm Exp $
++#	$OpenBSD: cert-hostkey.sh,v 1.30 2025/12/22 03:36:43 djm Exp $
+ #	Placed in the Public Domain.
+ 
+ tid="certified host keys"
+@@ -220,9 +220,20 @@ test_one() {
+ 		rsa-sha2-*)	tflag="-t $ktype"; ca="$OBJ/host_ca_key2" ;;
+ 		*)		tflag=""; ca="$OBJ/host_ca_key" ;;
+ 		esac
+-		${SSHKEYGEN} -q -s $ca $tflag -I "regress host key for $USER" \
+-		    $sign_opts $OBJ/cert_host_key_${kt} ||
+-			fatal "couldn't sign cert_host_key_${kt}"
++		if test -z "$hosts" ; then
++			# Empty principals section.
++			${SSHKEYGEN} -q -s $ca $tflag $sign_opts \
++			    -I "regress host key for $USER" \
++			    $OBJ/cert_host_key_${kt} 2>/dev/null ||
++				fatal "couldn't sign cert_host_key_${kt}"
++		else
++			# Be careful with quoting principals, which may contain
++			# wilcards.
++			${SSHKEYGEN} -q -s $ca $tflag $sign_opts \
++			    -I "regress host key for $USER" -n "$hosts" \
++			    $OBJ/cert_host_key_${kt} ||
++				fatal "couldn't sign cert_host_key_${kt}"
++		fi
+ 		(
+ 			cat $OBJ/sshd_proxy_bak
+ 			echo HostKey $OBJ/cert_host_key_${kt}
+-- 
+2.53.0
+

--- a/SOURCES/openssh-9.8p1-upstream-when-refusing-a-certificate-for-user-authen.patch
+++ b/SOURCES/openssh-9.8p1-upstream-when-refusing-a-certificate-for-user-authen.patch
@@ -1,0 +1,144 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/9ffa98111dbe53bf86d07da8e01ded8c5c25456b
+Backport notes:
+- Certain headers in the c code had to be replaced.
+
+From 9ffa98111dbe53bf86d07da8e01ded8c5c25456b Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Wed, 6 Aug 2025 04:53:04 +0000
+Subject: [PATCH] upstream: when refusing a certificate for user
+ authentication, log
+
+enough information to identify the certificate in addition to the reason why
+it was being denied. Makes debugging certificate authz problems a bit easier.
+
+ok dlg@
+
+OpenBSD-Commit-ID: 4c4621b2e70412754b3fe7540af8f4bf02b722b1
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ auth2-hostbased.c  | 14 +++++++++++---
+ auth2-pubkey.c     | 12 +++++++++---
+ auth2-pubkeyfile.c | 23 ++++++++++++++++-------
+ 3 files changed, 36 insertions(+), 13 deletions(-)
+
+diff --git a/auth2-hostbased.c b/auth2-hostbased.c
+index eb21479a0..e28134a1a 100644
+--- a/auth2-hostbased.c
++++ b/auth2-hostbased.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-hostbased.c,v 1.53 2024/05/17 00:30:23 djm Exp $ */
++/* $OpenBSD: auth2-hostbased.c,v 1.54 2025/08/06 04:53:04 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  *
+@@ -236,8 +236,16 @@ hostbased_key_allowed(struct ssh *ssh, struct passwd *pw,
+ 
+ 	if (sshkey_is_cert(key) &&
+ 	    sshkey_cert_check_authority_now(key, 1, 0, 0, lookup, &reason)) {
+-		error("%s", reason);
+-		auth_debug_add("%s", reason);
++		if ((fp = sshkey_fingerprint(key->cert->signature_key,
++		    options.fingerprint_hash, SSH_FP_DEFAULT)) == NULL)
++			fatal_f("sshkey_fingerprint fail");
++		error("Refusing certificate ID \"%s\" serial=%llu signed by "
++		    "%s CA %s: %s", key->cert->key_id, key->cert->serial,
++		    sshkey_type(key->cert->signature_key), fp, reason);
++		auth_debug_add("Refused Certificate ID \"%s\" serial=%llu: %s",
++		    key->cert->key_id, (unsigned long long)key->cert->serial,
++		    reason);
++		free(fp);
+ 		return 0;
+ 	}
+ 
+diff --git a/auth2-pubkey.c b/auth2-pubkey.c
+index aa24fda05..221b242f8 100644
+--- a/auth2-pubkey.c
++++ b/auth2-pubkey.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-pubkey.c,v 1.120 2024/05/17 00:30:23 djm Exp $ */
++/* $OpenBSD: auth2-pubkey.c,v 1.123 2025/08/06 04:53:04 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2010 Damien Miller.  All rights reserved.
+@@ -590,8 +590,14 @@ user_cert_trusted_ca(struct passwd *pw, struct sshkey *key,
+ 		if ((final_opts = sshauthopt_merge(principals_opts,
+ 		    cert_opts, &reason)) == NULL) {
+  fail_reason:
+-			error("%s", reason);
+-			auth_debug_add("%s", reason);
++			error("Refusing certificate ID \"%s\" serial=%llu "
++			    "signed by %s CA %s: %s", key->cert->key_id,
++			    key->cert->serial,
++			    sshkey_type(key->cert->signature_key), ca_fp,
++			    reason);
++			auth_debug_add("Refused Certificate ID \"%s\" "
++			    "serial=%llu: %s", key->cert->key_id,
++			    (unsigned long long)key->cert->serial, reason);
+ 			goto out;
+ 		}
+ 	}
+diff --git a/auth2-pubkeyfile.c b/auth2-pubkeyfile.c
+index 31e7481fb..531a266ac 100644
+--- a/auth2-pubkeyfile.c
++++ b/auth2-pubkeyfile.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: auth2-pubkeyfile.c,v 1.4 2023/03/05 05:34:09 dtucker Exp $ */
++/* $OpenBSD: auth2-pubkeyfile.c,v 1.5 2025/08/06 04:53:04 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2010 Damien Miller.  All rights reserved.
+@@ -344,15 +344,15 @@ auth_check_authkey_line(struct passwd *pw, struct sshkey *key,
+ 	/* Parse and check options present in certificate */
+ 	if ((certopts = sshauthopt_from_cert(key)) == NULL) {
+ 		reason = "Invalid certificate options";
+-		goto fail_reason;
++		goto cert_fail_reason;
+ 	}
+ 	if (auth_authorise_keyopts(pw, certopts, 0,
+ 	    remote_ip, remote_host, loc) != 0) {
+ 		reason = "Refused by certificate options";
+-		goto fail_reason;
++		goto cert_fail_reason;
+ 	}
+ 	if ((finalopts = sshauthopt_merge(keyopts, certopts, &reason)) == NULL)
+-		goto fail_reason;
++		goto cert_fail_reason;
+ 
+ 	/*
+ 	 * If the user has specified a list of principals as
+@@ -362,12 +362,12 @@ auth_check_authkey_line(struct passwd *pw, struct sshkey *key,
+ 	if (keyopts->cert_principals != NULL &&
+ 	    !match_principals_option(keyopts->cert_principals, key->cert)) {
+ 		reason = "Certificate does not contain an authorized principal";
+-		goto fail_reason;
++		goto cert_fail_reason;
+ 	}
+ 	if (sshkey_cert_check_authority_now(key, 0, 0, 0,
+ 	    keyopts->cert_principals == NULL ? pw->pw_name : NULL,
+ 	    &reason) != 0)
+-		goto fail_reason;
++		goto cert_fail_reason;
+ 
+ 	verbose("Accepted certificate ID \"%s\" (serial %llu) "
+ 	    "signed by CA %s %s found at %s",
+@@ -386,8 +386,17 @@ auth_check_authkey_line(struct passwd *pw, struct sshkey *key,
+ 	ret = 0;
+ 	goto out;
+ 
++ cert_fail_reason:
++	error("Refusing certificate ID \"%s\" serial=%llu "
++	    "signed by %s CA %s via %s: %s", key->cert->key_id,
++	    key->cert->serial, sshkey_type(key->cert->signature_key),
++	    fp, loc, reason);
++	auth_debug_add("Refused Certificate ID \"%s\" serial=%llu: %s",
++	    key->cert->key_id, (unsigned long long)key->cert->serial, reason);
++	goto out;
++
+  fail_reason:
+-	error("%s", reason);
++	error("%s at %s", reason, loc);
+ 	auth_debug_add("%s", reason);
+  out:
+ 	free(fp);
+-- 
+2.53.0

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -5,7 +5,7 @@
 # start the release from openssh_rel as other packages requires
 
 # XCP-ng sub release number
-%define xcpng_subrel 2
+%define xcpng_subrel 3
 
 %global WITH_SELINUX 0
 
@@ -124,6 +124,11 @@ Patch52: openssh-6.7p1-coverity.patch
 # XCP-ng patches
 Patch1000: openssh-7.4p1-CVE-2025-26465-Fix-cases-where-error-codes-were-not-correc.patch
 Patch1001: openssh-9.8p1-deprecated-ssh-rsa-warning.patch
+Patch1002: openssh-9.8p1-upstream-when-refusing-a-certificate-for-user-authen.patch
+Patch1003: openssh-9.8p1-CVE-2026-35414-when-certificate-support-was-added.patch
+Patch1004: openssh-9.8p1-CVE-2026-35414-regression-test-for-certificates.patch
+Patch1005: openssh-9.8p1-upstream-correctly-match-ECDSA-signature-algorithms.patch
+Patch1006: openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patch
 
 Source24: ssh_config
 Source25: sshd_config
@@ -509,6 +514,12 @@ cat %{_sysconfdir}/ssh/ssh_config.dup > %{_sysconfdir}/ssh/ssh_config
 %endif
 
 %changelog
+* Fri Apr 17 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 9.8p1-1.2.3
+- Add patch upstream log when refusing a certificate as dependency for CVE-2026-35414 patch
+- Fix CVE-2026-35414 (Bypass of authorized_keys)
+- Test for CVE-2026-35414 (with a fix for this test)
+- Fix ECDSA Bypass
+
 * Thu Mar 12 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 9.8p1-1.2.2
 - Temporally enabled ssh-rsa with warning.
   Docs: https://datatracker.ietf.org/doc/html/rfc8332


### PR DESCRIPTION
Card: XCPNG-3174

Context:
A security vulnerability has been fixed in OpenSSH Server. This vulnerability concerns a weakness in the handling of CAs in the authorized-keys file, which could allow an unauthorized attacker to access a server.

ECDSA: Upstream patch: https://github.com/openssh/openssh-portable/commit/fd1c7e131f331942d20f42f31e79912d570081fa
NIST: https://nvd.nist.gov/vuln/detail/CVE-2026-35414
More info: https://marc.info/?l=openssh-unix-dev&m=177513443901484&w=2
CA: Upstream patch: https://github.com/openssh/openssh-portable/commit/5166b6cbf2b6103117a79f90a68068e89e02bf66

Scratch Build: https://koji.xcp-ng.org/taskinfo?taskID=103894