### PR TITLE
Fix multiple CVE

### DIFF
--- a/SOURCES/openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-option.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-option.patch
@@ -1,0 +1,52 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/fc86875e6acb36401dfc1dfb6b628a9d1460f367
+Backport notes:
+- Only the "version identifier/RCS ID" in the header has been updated
+  to reflect our current base file.
+
+From fc86875e6acb36401dfc1dfb6b628a9d1460f367 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Wed, 9 Apr 2025 07:00:03 +0000
+Subject: [PATCH] upstream: Fix logic error in DisableForwarding option. This
+ option
+
+was documented as disabling X11 and agent forwarding but it failed to do so.
+Spotted by Tim Rice.
+
+OpenBSD-Commit-ID: fffc89195968f7eedd2fc57f0b1f1ef3193f5ed1
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ session.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/session.c b/session.c
+index 52a4a3446..6444c77f3 100644
+--- a/session.c
++++ b/session.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: session.c,v 1.338 2024/05/17 00:30:24 djm Exp $ */
++/* $OpenBSD: session.c,v 1.341 2025/04/09 07:00:03 djm Exp $ */
+ /*
+  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+  *                    All rights reserved
+@@ -2171,7 +2171,8 @@ session_auth_agent_req(struct ssh *ssh, Session *s)
+ 	if ((r = sshpkt_get_end(ssh)) != 0)
+ 		sshpkt_fatal(ssh, r, "%s: parse packet", __func__);
+ 	if (!auth_opts->permit_agent_forwarding_flag ||
+-	    !options.allow_agent_forwarding) {
++	    !options.allow_agent_forwarding ||
++	    options.disable_forwarding) {
+ 		debug_f("agent forwarding disabled");
+ 		return 0;
+ 	}
+@@ -2566,7 +2567,7 @@ session_setup_x11fwd(struct ssh *ssh, Session *s)
+ 		ssh_packet_send_debug(ssh, "X11 forwarding disabled by key options.");
+ 		return 0;
+ 	}
+-	if (!options.x11_forwarding) {
++	if (!options.x11_forwarding || options.disable_forwarding) {
+ 		debug("X11 forwarding disabled in server configuration file.");
+ 		return 0;
+ 	}
+-- 
+2.54.0
+

--- a/SOURCES/openssh-9.8p1-CVE-2025-61984-Improve-rules-for-expansion-of-username.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2025-61984-Improve-rules-for-expansion-of-username.patch
@@ -1,0 +1,71 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043
+Backport notes:
+- This backport only keeps the valid_ruser() hardening (rejecting
+  control characters in usernames), which is the part of the upstream
+  fix that applies to our 9.8p1 base.
+- The rest of the upstream commit (tracking user_on_commandline /
+  user_was_default / user_expanded and restricting %-expansion to
+  usernames read from the configuration file) has been dropped: 9.8p1
+  does not yet support %-expansion of the "User" keyword at all (that
+  feature was introduced upstream after 9.8p1), so that attack vector
+  does not exist in this codebase. options.user is already validated
+  with valid_ruser() exactly once, before ssh_config is parsed, so only
+  command-line-supplied usernames (-l, user@host, ssh:// URI) are
+  checked, which matches upstream's end goal that config-supplied
+  literal usernames are trusted and not re-validated.
+- Only the "version identifier/RCS ID" in the header has been updated
+  to reflect our current base file.
+
+From 35d5917652106aede47621bb3f64044604164043 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 00:29:09 +0000
+Subject: [PATCH] upstream: Improve rules for %-expansion of username.
+
+Usernames passed on the commandline will no longer be subject to
+% expansion. Some tools invoke ssh with connection information
+(i.e. usernames and host names) supplied from untrusted sources.
+These may contain % expansion sequences which could yield
+unexpected results.
+
+Since openssh-9.6, all usernames have been subject to validity
+checking. This change tightens the validity checks by refusing
+usernames that include control characters (again, these can cause
+surprises when supplied adversarially).
+
+This change also relaxes the validity checks in one small way:
+usernames supplied via the configuration file as literals (i.e.
+include no % expansion characters) are not subject to these
+validity checks. This allows usernames that contain arbitrary
+characters to be used, but only via configuration files. This
+is done on the basis that ssh's configuration is trusted.
+
+Pointed out by David Leadbeater, ok deraadt@
+
+OpenBSD-Commit-ID: e2f0c871fbe664aba30607321575e7c7fc798362
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ ssh.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/ssh.c b/ssh.c
+index aee4cf6..bca1085 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: ssh.c,v 1.600 2024/01/11 01:45:36 djm Exp $ */
++/* $OpenBSD: ssh.c,v 1.617 2025/09/04 00:29:09 djm Exp $ */
+ /*
+  * Author: Tatu Ylonen <ylo@cs.hut.fi>
+  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+@@ -650,6 +650,8 @@ valid_ruser(const char *s)
+ 	if (*s == '-')
+ 		return 0;
+ 	for (i = 0; s[i] != 0; i++) {
++		if (iscntrl((u_char)s[i]))
++			return 0;
+ 		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
+ 			return 0;
+ 		/* Disallow '-' after whitespace */
+--
+2.54.0
+

--- a/SOURCES/openssh-9.8p1-CVE-2025-61985-don-t-allow-0-characters-in-url-encoded-str.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2025-61985-don-t-allow-0-characters-in-url-encoded-str.patch
@@ -1,0 +1,51 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/43b3bff47bb029f2299bacb6a36057981b39fdb0
+Backport notes:
+- Only the "version identifier/RCS ID" in headers has been modified. 
+
+From 43b3bff47bb029f2299bacb6a36057981b39fdb0 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 00:30:06 +0000
+Subject: [PATCH] upstream: don't allow \0 characters in url-encoded strings.
+
+Suggested by David Leadbeater, ok deraadt@
+
+OpenBSD-Commit-ID: c92196cef0f970ceabc1e8007a80b01e9b7cd49c
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ misc.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/misc.c b/misc.c
+index 5c384c63d..c80f65554 100644
+--- a/misc.c
++++ b/misc.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: misc.c,v 1.196 2024/06/06 17:15:25 djm Exp $ */
++/* $OpenBSD: misc.c,v 1.205 2025/09/04 00:30:06 djm Exp $ */
+ /*
+  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+  * Copyright (c) 2005-2020 Damien Miller.  All rights reserved.
+@@ -994,7 +994,7 @@ urldecode(const char *src)
+ 	size_t srclen;
+ 
+ 	if ((srclen = strlen(src)) >= SIZE_MAX)
+-		fatal_f("input too large");
++		return NULL;
+ 	ret = xmalloc(srclen + 1);
+ 	for (dst = ret; *src != '\0'; src++) {
+ 		switch (*src) {
+@@ -1002,9 +1002,10 @@ urldecode(const char *src)
+ 			*dst++ = ' ';
+ 			break;
+ 		case '%':
++			/* note: don't allow \0 characters */
+ 			if (!isxdigit((unsigned char)src[1]) ||
+ 			    !isxdigit((unsigned char)src[2]) ||
+-			    (ch = hexchar(src + 1)) == -1) {
++			    (ch = hexchar(src + 1)) == -1 || ch == 0) {
+ 				free(ret);
+ 				return NULL;
+ 			}
+-- 
+2.54.0
+

--- a/SOURCES/openssh-9.8p1-CVE-2026-35385-when-downloading-files-as-root-in-legacy-O-.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2026-35385-when-downloading-files-as-root-in-legacy-O-.patch
@@ -1,0 +1,48 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/487e8ac146f7d6616f65c125d5edb210519b833a
+Backport notes:
+- Only the "version identifier/RCS ID" in headers has been modified. 
+
+From 487e8ac146f7d6616f65c125d5edb210519b833a Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:42:16 +0000
+Subject: [PATCH] upstream: when downloading files as root in legacy (-O) mode
+ and
+
+without the -p (preserve modes) flag set, clear setuid/setgid bits from
+downloaded files as one might expect.
+
+AFAIK this bug dates back to the original Berkeley rcp program.
+
+Reported by Christos Papakonstantinou of Cantina and Spearbit.
+
+OpenBSD-Commit-ID: 49e902fca8dd933a92a9b547ab31f63e86729fa1
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ scp.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/scp.c b/scp.c
+index e46daef90..1faa9a555 100644
+--- a/scp.c
++++ b/scp.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: scp.c,v 1.261 2024/06/26 23:14:14 deraadt Exp $ */
++/* $OpenBSD: scp.c,v 1.273 2026/04/02 07:42:16 djm Exp $ */
+ /*
+  * scp - secure remote copy.  This is basically patched BSD rcp which
+  * uses ssh to do the data transfer (instead of using rcmd).
+@@ -1678,8 +1678,10 @@ sink(int argc, char **argv, const char *src)
+ 
+ 	setimes = targisdir = 0;
+ 	mask = umask(0);
+-	if (!pflag)
++	if (!pflag) {
++		mask |= 07000;
+ 		(void) umask(mask);
++	}
+ 	if (argc != 1) {
+ 		run_err("ambiguous target");
+ 		exit(1);
+-- 
+2.54.0
+

--- a/SOURCES/openssh-9.8p1-CVE-2026-35388-add-missing-askpass-check-when-using.patch
+++ b/SOURCES/openssh-9.8p1-CVE-2026-35388-add-missing-askpass-check-when-using.patch
@@ -1,0 +1,48 @@
+Origin: upstream, https://github.com/openssh/openssh-portable/commit/c805b97b67c774e0bf922ffb29dfbcda9d7b5add
+Backport notes:
+- Only the "version identifier/RCS ID" in headers has been modified. 
+
+From c805b97b67c774e0bf922ffb29dfbcda9d7b5add Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 2 Apr 2026 07:39:57 +0000
+Subject: [PATCH] upstream: add missing askpass check when using
+
+ControlMaster=ask/autoask and "ssh -O proxy ..."; reported by Michalis
+Vasileiadis
+
+OpenBSD-Commit-ID: 8dd7b9b96534e9a8726916b96d36bed466d3836a
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+ mux.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/mux.c b/mux.c
+index 5e20c7760..0cd169732 100644
+--- a/mux.c
++++ b/mux.c
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: mux.c,v 1.101 2023/11/23 03:37:05 dtucker Exp $ */
++/* $OpenBSD: mux.c,v 1.113 2026/04/02 07:39:57 djm Exp $ */
+ /*
+  * Copyright (c) 2002-2008 Damien Miller <djm@openbsd.org>
+  *
+@@ -1172,6 +1172,16 @@ mux_master_process_proxy(struct ssh *ssh, u_int rid,
+ 
+ 	debug_f("channel %d: proxy request", c->self);
+ 
++	if (options.control_master == SSHCTL_MASTER_ASK ||
++	    options.control_master == SSHCTL_MASTER_AUTO_ASK) {
++		if (!ask_permission("Allow multiplex proxy connection?")) {
++			debug2_f("proxy refused by user");
++			reply_error(reply, MUX_S_PERMISSION_DENIED, rid,
++			    "Permission denied");
++			return 0;
++		}
++	}
++
+ 	c->mux_rcb = channel_proxy_downstream;
+ 	if ((r = sshbuf_put_u32(reply, MUX_S_PROXY)) != 0 ||
+ 	    (r = sshbuf_put_u32(reply, rid)) != 0)
+-- 
+2.54.0
+

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -131,6 +131,7 @@ Patch1006: openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patc
 Patch1007: openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-option.patch
 Patch1008: openssh-9.8p1-CVE-2025-61984-Improve-rules-for-expansion-of-username.patch
 Patch1009: openssh-9.8p1-CVE-2025-61985-don-t-allow-0-characters-in-url-encoded-str.patch
+Patch1010: openssh-9.8p1-CVE-2026-35385-when-downloading-files-as-root-in-legacy-O-.patch
 
 Source24: ssh_config
 Source25: sshd_config
@@ -525,6 +526,9 @@ cat %{_sysconfdir}/ssh/ssh_config.dup > %{_sysconfdir}/ssh/ssh_config
 - Fix CVE-2025-61985 ('\0' characters were not rejected in url-encoded
   strings such as ssh:// URIs, which could allow NUL-byte smuggling into
   values used by ProxyCommand, potentially leading to code execution)
+- Fix CVE-2026-35385 (files downloaded as root with scp's legacy -O mode
+  but without -p did not have their setuid/setgid bits cleared, allowing
+  privilege escalation)
 
 * Wed Apr 29 2026 Vincent Michel <vincent.michel@vates.tech> - 9.8p1-1.2.4
 - Disable the use of ssh-rsa with SHA-1 (temporarily enabled in 9.8p1-1.2.2)

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -5,7 +5,7 @@
 # start the release from openssh_rel as other packages requires
 
 # XCP-ng sub release number
-%define xcpng_subrel 4
+%define xcpng_subrel 5
 
 %global WITH_SELINUX 0
 
@@ -128,6 +128,7 @@ Patch1003: openssh-9.8p1-CVE-2026-35414-when-certificate-support-was-added.patch
 Patch1004: openssh-9.8p1-CVE-2026-35414-regression-test-for-certificates.patch
 Patch1005: openssh-9.8p1-upstream-correctly-match-ECDSA-signature-algorithms.patch
 Patch1006: openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patch
+Patch1007: openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-option.patch
 
 Source24: ssh_config
 Source25: sshd_config
@@ -513,6 +514,10 @@ cat %{_sysconfdir}/ssh/ssh_config.dup > %{_sysconfdir}/ssh/ssh_config
 %endif
 
 %changelog
+* Wed Jul 15 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 9.8p1-1.2.5
+- Fix CVE-2025-32728 (X11 and agent forwarding were not disabled by the
+  DisableForwarding option due to a logic error)
+
 * Wed Apr 29 2026 Vincent Michel <vincent.michel@vates.tech> - 9.8p1-1.2.4
 - Disable the use of ssh-rsa with SHA-1 (temporarily enabled in 9.8p1-1.2.2)
 

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -132,6 +132,7 @@ Patch1007: openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-opt
 Patch1008: openssh-9.8p1-CVE-2025-61984-Improve-rules-for-expansion-of-username.patch
 Patch1009: openssh-9.8p1-CVE-2025-61985-don-t-allow-0-characters-in-url-encoded-str.patch
 Patch1010: openssh-9.8p1-CVE-2026-35385-when-downloading-files-as-root-in-legacy-O-.patch
+Patch1011: openssh-9.8p1-CVE-2026-35388-add-missing-askpass-check-when-using.patch
 
 Source24: ssh_config
 Source25: sshd_config
@@ -529,6 +530,8 @@ cat %{_sysconfdir}/ssh/ssh_config.dup > %{_sysconfdir}/ssh/ssh_config
 - Fix CVE-2026-35385 (files downloaded as root with scp's legacy -O mode
   but without -p did not have their setuid/setgid bits cleared, allowing
   privilege escalation)
+- Fix CVE-2026-35388 (missing askpass confirmation when using
+  ControlMaster=ask/autoask with "ssh -O proxy ...")
 
 * Wed Apr 29 2026 Vincent Michel <vincent.michel@vates.tech> - 9.8p1-1.2.4
 - Disable the use of ssh-rsa with SHA-1 (temporarily enabled in 9.8p1-1.2.2)

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -130,6 +130,7 @@ Patch1005: openssh-9.8p1-upstream-correctly-match-ECDSA-signature-algorithms.pat
 Patch1006: openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patch
 Patch1007: openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-option.patch
 Patch1008: openssh-9.8p1-CVE-2025-61984-Improve-rules-for-expansion-of-username.patch
+Patch1009: openssh-9.8p1-CVE-2025-61985-don-t-allow-0-characters-in-url-encoded-str.patch
 
 Source24: ssh_config
 Source25: sshd_config
@@ -521,6 +522,9 @@ cat %{_sysconfdir}/ssh/ssh_config.dup > %{_sysconfdir}/ssh/ssh_config
 - Fix CVE-2025-61984 (ssh(1) did not reject control characters in remote
   usernames supplied on the commandline, which could be abused to inject
   data into a ProxyCommand relying on %r expansion)
+- Fix CVE-2025-61985 ('\0' characters were not rejected in url-encoded
+  strings such as ssh:// URIs, which could allow NUL-byte smuggling into
+  values used by ProxyCommand, potentially leading to code execution)
 
 * Wed Apr 29 2026 Vincent Michel <vincent.michel@vates.tech> - 9.8p1-1.2.4
 - Disable the use of ssh-rsa with SHA-1 (temporarily enabled in 9.8p1-1.2.2)

--- a/SPECS/openssh.spec
+++ b/SPECS/openssh.spec
@@ -129,6 +129,7 @@ Patch1004: openssh-9.8p1-CVE-2026-35414-regression-test-for-certificates.patch
 Patch1005: openssh-9.8p1-upstream-correctly-match-ECDSA-signature-algorithms.patch
 Patch1006: openssh-9.8p1-upstream-correctly-quote-wildcard-host-certificate.patch
 Patch1007: openssh-9.8p1-CVE-2025-32728-Fix-logic-error-in-DisableForwarding-option.patch
+Patch1008: openssh-9.8p1-CVE-2025-61984-Improve-rules-for-expansion-of-username.patch
 
 Source24: ssh_config
 Source25: sshd_config
@@ -517,6 +518,9 @@ cat %{_sysconfdir}/ssh/ssh_config.dup > %{_sysconfdir}/ssh/ssh_config
 * Wed Jul 15 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 9.8p1-1.2.5
 - Fix CVE-2025-32728 (X11 and agent forwarding were not disabled by the
   DisableForwarding option due to a logic error)
+- Fix CVE-2025-61984 (ssh(1) did not reject control characters in remote
+  usernames supplied on the commandline, which could be abused to inject
+  data into a ProxyCommand relying on %r expansion)
 
 * Wed Apr 29 2026 Vincent Michel <vincent.michel@vates.tech> - 9.8p1-1.2.4
 - Disable the use of ssh-rsa with SHA-1 (temporarily enabled in 9.8p1-1.2.2)


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3552

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

This is a low security update.
Several security vulnerabilities have been revealed in OpenSSH 10.3; although default configurations disable the affected features (rendering most of the vulnerabilities unexploitable), it is possible for users to alter these settings.
Note: This update follows https://github.com/xcp-ng-rpms/openssh/pull/12, which addressed more critical vulnerabilities.

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

Since this involves a less critical security vulnerability and the default configuration is secure a standard update remains the ideal approach.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Five minor security flaws have been fixed in OpenSSH:
- CVE-2025-32728 --> A logic error was fixed regarding cases where `x11_forwarding` is disabled.
- CVE-2025-61984 --> Checks for forbidden characters have been tightened.
- CVE-2025-61985 --> A specific character has been disallowed in URL-encoded strings.
- CVE-2026-35385 --> The behavior when using `scp` with `-O` (without `-p`) has been corrected to prevent privilege escalation.
- CVE-2026-35388 --> The behavior regarding "ask/autoask" or `ssh -O proxy ...` has been corrected.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

Users who have uploaded files to their XCP-ng server via "scp -O" without using "-p" should exercise caution. The uploaded file could potentially allow for privilege escalation. Clearing the setuid/setgid bits is required.

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

This is a security update, there is no functional update

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

~~Nothing at the moment.~~
What I verified:
- Connection using ed25519 keys still works.
- CVE-2025-32728 is correctly fixed (agentForwarding).
- CVE-2025-61984 is correctly fixed (Control characters in commandLine).
- CVE-2025-61985 is correctly fixed (%-encoded).
- CVE-2026-35385 is correctly fixed (scp -O without -p).
- CVE-2026-35388 is correctly fixed (ControlMaster=ask).

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

~~I would run tests to verify that OpenSSH is working correctly. I would also verify that the patches produce the expected behavior.~~ (See above)

From the user's perspective, it is important to continue using OpenSSH and "scp" commands as before, in order to confirm that the behavior remains as expected.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

OpenSSH is already being used by the CI.

#### What tests have been or will be added to CI for this change? If none, explain why.

OpenSSH is already being used by the CI.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
